### PR TITLE
Continue retention run on error

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ func getApp() components.App {
 	app := components.App{}
 	app.Name = "rt-retention"
 	app.Description = "Enforce retention policies"
-	app.Version = "v0.1.0"
+	app.Version = "v0.1.1"
 	app.Commands = getCommands()
 	return app
 }


### PR DESCRIPTION
Rather than stopping a retention run when an error occurs, skip retention spec and keep going.
Collect and summarize run errors after the run has completed.